### PR TITLE
added readonly switch for input function

### DIFF
--- a/Functions/Public/input.ps1
+++ b/Functions/Public/input.ps1
@@ -24,25 +24,28 @@ Function input {
         [Parameter(Mandatory = $false, Position = 2)]
         [switch]$required,
 
-        [Parameter(Position = 3)]
-        [String]$Class,
+        [Parameter(Mandatory = $false, Position = 3)]
+        [switch]$readonly,
 
         [Parameter(Position = 4)]
-        [String]$Id,
+        [String]$Class,
 
         [Parameter(Position = 5)]
-        [String]$Style,
+        [String]$Id,
 
         [Parameter(Position = 6)]
-        [String]$value,
+        [String]$Style,
 
         [Parameter(Position = 7)]
+        [String]$value,
+
+        [Parameter(Position = 8)]
         [Hashtable]$Attributes,
 
         [Parameter(
             ValueFromPipeline = $true,
             Mandatory = $false,
-            Position = 7
+            Position = 9
         )]
         [scriptblock]
         $Content

--- a/pshtml.psd1
+++ b/pshtml.psd1
@@ -12,7 +12,7 @@
 RootModule = 'pshtml.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.14'
+ModuleVersion = '0.5.15'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
**Summary:**

- A minor feature - input function has readonly switch.
- Parameter positions are corrected. 
- A minor version number changed in PSD1 file. 

Added a **readonly** switch parameter. Refer the below shown code!

```PowerShell
input -type text -name "LoggedOnUser" -value $env:USERNAME -readonly
```
Which in-turns gives us a text field as READONLY - End users can't edit the value !

```html
<input type="text" name="LoggedOnUser" value="ChenV" readonly="True" >
```