### PR TITLE
added -raw switch to get-content

### DIFF
--- a/Functions/Private/Get-HTMLTemplate.ps1
+++ b/Functions/Private/Get-HTMLTemplate.ps1
@@ -61,7 +61,7 @@ html{
         write-verbose "Template file found at $($Template.FullName)"
     }
 
-    $Rawcontent = Get-Content $Template.FullName
+    $Rawcontent = Get-Content $Template.FullName -Raw
     $Content = [scriptBlock]::Create($Rawcontent).Invoke()
     return $content
 


### PR DESCRIPTION
# Pull Request Fix Template Parsing

This makes sure the $rawcontent var is really "raw" and allows proper parsing of template files which are currently broken. When parsing some template files now Invoke returns errors due to get-content messing with line breaks etc.

### Please tell us , the type of Change you are submiting:
Select one of the following: 

- [X] Bug
- [ ] Feature
- [ ] Minor Change

### Does it fix an existing issue? Please tell us which one

Didn't see this one reported yet so I don't believe so.

### Description of what's been changed
Just added -Raw to the Get-Content cmdlet.

### Results of your tests (If applicable)
Allowed proper parsing of template files in my testing.
