### PR TITLE
Add Linux support and testing

### DIFF
--- a/Examples/example01.ps1
+++ b/Examples/example01.ps1
@@ -76,4 +76,4 @@ $Document = html {
 }
 
 
-$Document > .\PSHTML_Example.html
+$Document > .\PSHtml_Example.html

--- a/PSHtml.psm1
+++ b/PSHtml.psm1
@@ -23,7 +23,7 @@ foreach ($Private in $PrivateFunctions){
 }
 
 write-verbose -Message "Loading Private Functions"
-$PublicFunctions = Get-ChildItem -Path "$ScriptPath\Functions\public" -Filter *.ps1 | Select-Object -ExpandProperty FullName
+$PublicFunctions = Get-ChildItem -Path "$ScriptPath\Functions\Public" -Filter *.ps1 | Select-Object -ExpandProperty FullName
 
 foreach ($public in $PublicFunctions){
     write-verbose "importing function $($function)"

--- a/Tests/Address.Tests.ps1
+++ b/Tests/Address.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Address" {

--- a/Tests/Address.Tests.ps1
+++ b/Tests/Address.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Address" {

--- a/Tests/Area.Tests.ps1
+++ b/Tests/Area.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing area" {

--- a/Tests/Area.Tests.ps1
+++ b/Tests/Area.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing area" {

--- a/Tests/Article.Tests.ps1
+++ b/Tests/Article.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing article" {

--- a/Tests/Article.Tests.ps1
+++ b/Tests/Article.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing article" {

--- a/Tests/Aside.Tests.ps1
+++ b/Tests/Aside.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing aside" {

--- a/Tests/Aside.Tests.ps1
+++ b/Tests/Aside.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing aside" {

--- a/Tests/Body.Tests.ps1
+++ b/Tests/Body.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Body" {

--- a/Tests/Body.Tests.ps1
+++ b/Tests/Body.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Body" {

--- a/Tests/Caption.Tests.ps1
+++ b/Tests/Caption.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Caption" {

--- a/Tests/Caption.Tests.ps1
+++ b/Tests/Caption.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Caption" {

--- a/Tests/Col.Tests.ps1
+++ b/Tests/Col.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing col" {

--- a/Tests/Col.Tests.ps1
+++ b/Tests/Col.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing col" {

--- a/Tests/Colgroup.Tests.ps1
+++ b/Tests/Colgroup.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing colgroup" {

--- a/Tests/Colgroup.Tests.ps1
+++ b/Tests/Colgroup.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing colgroup" {

--- a/Tests/ConvertTo-HtmlTable.Tests.ps1
+++ b/Tests/ConvertTo-HtmlTable.Tests.ps1
@@ -8,7 +8,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 
 Describe "Testing ConvertTo-HTMLTable" {

--- a/Tests/ConvertTo-HtmlTable.Tests.ps1
+++ b/Tests/ConvertTo-HtmlTable.Tests.ps1
@@ -8,7 +8,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 
 Describe "Testing ConvertTo-HTMLTable" {

--- a/Tests/Div.Tests.ps1
+++ b/Tests/Div.Tests.ps1
@@ -32,7 +32,7 @@ Context "Testing PSHTML"{
 
         }
 
-        it "Testing content in child element" -Skip {
+        it "Testing content in child element" {
             $string -match "^.*>woop<.*" | should be $true
         }
 

--- a/Tests/Div.Tests.ps1
+++ b/Tests/Div.Tests.ps1
@@ -32,7 +32,7 @@ Context "Testing PSHTML"{
 
         }
 
-        it "Testing content in child element"{
+        it "Testing content in child element" -Skip {
             $string -match "^.*>woop<.*" | should be $true
         }
 

--- a/Tests/Div.Tests.ps1
+++ b/Tests/Div.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Div" {

--- a/Tests/Div.Tests.ps1
+++ b/Tests/Div.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Div" {

--- a/Tests/Footer.Tests.ps1
+++ b/Tests/Footer.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing footer" {

--- a/Tests/Footer.Tests.ps1
+++ b/Tests/Footer.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing footer" {

--- a/Tests/Form.Tests.ps1
+++ b/Tests/Form.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Form" {

--- a/Tests/Form.Tests.ps1
+++ b/Tests/Form.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Form" {

--- a/Tests/Form.Tests.ps1
+++ b/Tests/Form.Tests.ps1
@@ -34,7 +34,7 @@ Context "Testing PSHTML"{
 
         }
 
-        it "Testing primary parameters: Action"{
+        it "Testing primary parameters: Action" -Skip {
             $string -match '^<form.*action="action_Page\.php".*>'| should be $true
         }
 

--- a/Tests/Form.Tests.ps1
+++ b/Tests/Form.Tests.ps1
@@ -34,7 +34,7 @@ Context "Testing PSHTML"{
 
         }
 
-        it "Testing primary parameters: Action" -Skip {
+        it "Testing primary parameters: Action" {
             $string -match '^<form.*action="action_Page\.php".*>'| should be $true
         }
 

--- a/Tests/H1.Tests.ps1
+++ b/Tests/H1.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h1 - ScriptBlock" {

--- a/Tests/H1.Tests.ps1
+++ b/Tests/H1.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h1 - ScriptBlock" {

--- a/Tests/H2.Tests.ps1
+++ b/Tests/H2.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h2 - ScriptBlock" {

--- a/Tests/H2.Tests.ps1
+++ b/Tests/H2.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h2 - ScriptBlock" {

--- a/Tests/H3.Tests.ps1
+++ b/Tests/H3.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h3 - ScriptBlock" {

--- a/Tests/H3.Tests.ps1
+++ b/Tests/H3.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h3 - ScriptBlock" {

--- a/Tests/H4.Tests.ps1
+++ b/Tests/H4.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h4 - ScriptBlock" {

--- a/Tests/H4.Tests.ps1
+++ b/Tests/H4.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h4 - ScriptBlock" {

--- a/Tests/H5.Tests.ps1
+++ b/Tests/H5.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h5 - ScriptBlock" {

--- a/Tests/H5.Tests.ps1
+++ b/Tests/H5.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h5 - ScriptBlock" {

--- a/Tests/H6.Tests.ps1
+++ b/Tests/H6.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h6 - ScriptBlock" {

--- a/Tests/H6.Tests.ps1
+++ b/Tests/H6.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing h6 - ScriptBlock" {

--- a/Tests/Head.Tests.ps1
+++ b/Tests/Head.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing head" {

--- a/Tests/Head.Tests.ps1
+++ b/Tests/Head.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing head" {

--- a/Tests/Header.Tests.ps1
+++ b/Tests/Header.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing header" {

--- a/Tests/Header.Tests.ps1
+++ b/Tests/Header.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing header" {

--- a/Tests/Html.Tests.ps1
+++ b/Tests/Html.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing html - Scripblock" {

--- a/Tests/Html.Tests.ps1
+++ b/Tests/Html.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing html - Scripblock" {

--- a/Tests/Meter.Tests.ps1
+++ b/Tests/Meter.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing meter" {

--- a/Tests/Meter.Tests.ps1
+++ b/Tests/Meter.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing meter" {

--- a/Tests/Output.Tests.ps1
+++ b/Tests/Output.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing output" {

--- a/Tests/Output.Tests.ps1
+++ b/Tests/Output.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing output" {

--- a/Tests/Progress.Tests.ps1
+++ b/Tests/Progress.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
     Describe "Testing Progress - ScriptBlock" {
 
 

--- a/Tests/Progress.Tests.ps1
+++ b/Tests/Progress.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
     Describe "Testing Progress - ScriptBlock" {
 
 

--- a/Tests/Section.Tests.ps1
+++ b/Tests/Section.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Section" {

--- a/Tests/Section.Tests.ps1
+++ b/Tests/Section.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing Section" {

--- a/Tests/TextArea.Tests.ps1
+++ b/Tests/TextArea.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing output" {

--- a/Tests/TextArea.Tests.ps1
+++ b/Tests/TextArea.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing output" {

--- a/Tests/a.Tests.ps1
+++ b/Tests/a.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing a" {

--- a/Tests/a.Tests.ps1
+++ b/Tests/a.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing a" {

--- a/Tests/base.Tests.ps1
+++ b/Tests/base.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
     Describe "Testing base - ScriptBlock" {
 

--- a/Tests/base.Tests.ps1
+++ b/Tests/base.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
     Describe "Testing base - ScriptBlock" {
 

--- a/Tests/blockquote.tests.ps1
+++ b/Tests/blockquote.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing blockquote" {

--- a/Tests/blockquote.tests.ps1
+++ b/Tests/blockquote.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing blockquote" {

--- a/Tests/button.Tests.ps1.ps1
+++ b/Tests/button.Tests.ps1.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
     Describe "Testing button - ScriptBlock" {
 
 

--- a/Tests/button.Tests.ps1.ps1
+++ b/Tests/button.Tests.ps1.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
     Describe "Testing button - ScriptBlock" {
 
 

--- a/Tests/datalist.tests.ps1
+++ b/Tests/datalist.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing datalist" {

--- a/Tests/datalist.tests.ps1
+++ b/Tests/datalist.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing datalist" {

--- a/Tests/dd.tests.ps1
+++ b/Tests/dd.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dd" {

--- a/Tests/dd.tests.ps1
+++ b/Tests/dd.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dd" {

--- a/Tests/dl.tests.ps1
+++ b/Tests/dl.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dl" {

--- a/Tests/dl.tests.ps1
+++ b/Tests/dl.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dl" {

--- a/Tests/dt.tests.ps1
+++ b/Tests/dt.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dt" {

--- a/Tests/dt.tests.ps1
+++ b/Tests/dt.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing dt" {

--- a/Tests/em.Tests.ps1
+++ b/Tests/em.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing em" {

--- a/Tests/em.Tests.ps1
+++ b/Tests/em.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing em" {

--- a/Tests/fieldset.Tests.ps1
+++ b/Tests/fieldset.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
     Describe "Testing fieldset - ScriptBlock" {
 

--- a/Tests/fieldset.Tests.ps1
+++ b/Tests/fieldset.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
     Describe "Testing fieldset - ScriptBlock" {
 

--- a/Tests/figcaption.tests.ps1
+++ b/Tests/figcaption.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing figcaption" {

--- a/Tests/figcaption.tests.ps1
+++ b/Tests/figcaption.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing figcaption" {

--- a/Tests/figure.tests.ps1
+++ b/Tests/figure.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing figure" {

--- a/Tests/figure.tests.ps1
+++ b/Tests/figure.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing figure" {

--- a/Tests/hr.tests.ps1
+++ b/Tests/hr.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing hr" {

--- a/Tests/hr.tests.ps1
+++ b/Tests/hr.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing hr" {

--- a/Tests/img.Tests.ps1
+++ b/Tests/img.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing img - ScriptBlock" {

--- a/Tests/img.Tests.ps1
+++ b/Tests/img.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing img - ScriptBlock" {

--- a/Tests/keygen.Tests.ps1
+++ b/Tests/keygen.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing keygen" {

--- a/Tests/keygen.Tests.ps1
+++ b/Tests/keygen.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing keygen" {

--- a/Tests/label.Tests.ps1
+++ b/Tests/label.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
     Describe "Testing label - ScriptBlock" {
 
 

--- a/Tests/label.Tests.ps1
+++ b/Tests/label.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
     Describe "Testing label - ScriptBlock" {
 
 

--- a/Tests/legend.Tests.ps1
+++ b/Tests/legend.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
     Describe "Testing legend - ScriptBlock" {
 
 

--- a/Tests/legend.Tests.ps1
+++ b/Tests/legend.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
     Describe "Testing legend - ScriptBlock" {
 
 

--- a/Tests/li.tests.ps1
+++ b/Tests/li.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing li" {

--- a/Tests/li.tests.ps1
+++ b/Tests/li.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing li" {

--- a/Tests/link.tests.ps1
+++ b/Tests/link.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing link" {

--- a/Tests/link.tests.ps1
+++ b/Tests/link.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing link" {

--- a/Tests/meta.Tests.ps1
+++ b/Tests/meta.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing meta" {

--- a/Tests/meta.Tests.ps1
+++ b/Tests/meta.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing meta" {

--- a/Tests/nav.Tests.ps1
+++ b/Tests/nav.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing nav" {

--- a/Tests/nav.Tests.ps1
+++ b/Tests/nav.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing nav" {

--- a/Tests/ol.tests.ps1
+++ b/Tests/ol.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing ol" {

--- a/Tests/ol.tests.ps1
+++ b/Tests/ol.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing ol" {

--- a/Tests/optgroup.tests.ps1
+++ b/Tests/optgroup.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing optgroup" {

--- a/Tests/optgroup.tests.ps1
+++ b/Tests/optgroup.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing optgroup" {

--- a/Tests/option.tests.ps1
+++ b/Tests/option.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing option" {

--- a/Tests/option.tests.ps1
+++ b/Tests/option.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing option" {

--- a/Tests/p.tests.ps1
+++ b/Tests/p.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing p - Scriptblock" {

--- a/Tests/p.tests.ps1
+++ b/Tests/p.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing p - Scriptblock" {

--- a/Tests/pre.tests.ps1
+++ b/Tests/pre.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing pre" {

--- a/Tests/pre.tests.ps1
+++ b/Tests/pre.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing pre" {

--- a/Tests/selecttag.Tests.ps1
+++ b/Tests/selecttag.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
     Describe "Testing selecttag - ScriptBlock" {
 
 

--- a/Tests/selecttag.Tests.ps1
+++ b/Tests/selecttag.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
     Describe "Testing selecttag - ScriptBlock" {
 
 

--- a/Tests/small.Tests.ps1
+++ b/Tests/small.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing small" {

--- a/Tests/small.Tests.ps1
+++ b/Tests/small.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing small" {

--- a/Tests/strong.Tests.ps1
+++ b/Tests/strong.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing strong" {

--- a/Tests/strong.Tests.ps1
+++ b/Tests/strong.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing strong" {

--- a/Tests/style.Tests.ps1
+++ b/Tests/style.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
     Describe "Testing style - ScriptBlock" {
 

--- a/Tests/style.Tests.ps1
+++ b/Tests/style.Tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
     Describe "Testing style - ScriptBlock" {
 

--- a/Tests/ul.tests.ps1
+++ b/Tests/ul.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHTML -Force
+import-module .\PSHtml -Force
 
 Context "Testing PSHTML"{
     Describe "Testing ul" {

--- a/Tests/ul.tests.ps1
+++ b/Tests/ul.tests.ps1
@@ -10,7 +10,7 @@ set-location -Path $RootFolder.FullName
 
 Write-Verbose "Importing module"
 
-import-module .\PSHtml -Force
+import-module .\pshtml.psd1 -Force
 
 Context "Testing PSHTML"{
     Describe "Testing ul" {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ install:
 build: off
 test_script:
 - ps: >- 
-    .\CI\build.ps1
+    .\CI\Build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image:
 - Visual Studio 2017
-- Ubuntu
+- Ubuntu1804
 
 install:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,8 @@ image:
 
 install:
 - ps: >-
-    Install-PackageProvider -Name NuGet -Force
+  # Is this needed?
+  #  Install-PackageProvider -Name NuGet -Force
     
     Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-- Visual Studio 2017
+- Visual Studio 2015
 - Ubuntu1804
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ image:
 
 install:
 - ps: >-
-  # Is this needed?
-  #  Install-PackageProvider -Name NuGet -Force
-    
     Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
     
     Install-Module -Name Pester -Force -Scope CurrentUser

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+image:
+- Visual Studio 2017
+- Ubuntu
+
 install:
 - ps: >-
     Install-PackageProvider -Name NuGet -Force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ install:
 - ps: >-
     Install-PackageProvider -Name NuGet -Force
     
-    Install-Module -Name PSScriptAnalyzer -Force
+    Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
     
-    Install-Module -Name Pester -Force
+    Install-Module -Name Pester -Force -Scope CurrentUser
 build: off
 test_script:
 - ps: >- 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image:
 - Visual Studio 2015
-- Ubuntu1804
+- Ubuntu
 
 install:
 - ps: >-

--- a/pshtml.psd1
+++ b/pshtml.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSHtml.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.19'
+ModuleVersion = '0.5.20'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/pshtml.psd1
+++ b/pshtml.psd1
@@ -9,7 +9,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = 'pshtml.psm1'
+RootModule = 'PSHtml.psm1'
 
 # Version number of this module.
 ModuleVersion = '0.5.19'


### PR DESCRIPTION
# Pull Request - Add Linux support and testing

This pull request is to address the Linux half of https://github.com/Stephanevg/PSHTML/issues/54
It contains some minor bug fixes to make the module work in Linux and changes to tests to make tests run as intended in Linux.

### Please tell us , the type of Change you are submiting:
Select one of the following: 
- [X] Bug 
I'm going with bugfix, though it could be argued that it's a feature.

### Description of what's been changed
#Module
Corrected the case of some references to filenames, since Linux filesystems tend to be case-sensitive.
#Tests
Updated appveyor.yml to get AppVeyor to run the tests on Ubuntu.
Made import-module statements in tests more resilient to remove errors under Linux.

### Results of your tests (If applicable)
There are two outstanding issues with the tests:
Some of the tests use Get-Service as a way of generating data for the test; Get-Service does not exist on Linux. I need your opinion on how you'd like to change this.

Many of the tests generate an error: "Error occurred in Describe block" on the second test of the file. This ONLY happens on AppVeyor and the tests work fine when executed locally on an Ubuntu machine, so I think it's due to AppVeyor doing something I'm not expecting, or a version mismatch somewhere. I'm continuing to investigate this one.