### PR TITLE
New version of SUB and SUP with pester tests

### DIFF
--- a/PSHTML/Functions/Public/sub.ps1
+++ b/PSHTML/Functions/Public/sub.ps1
@@ -63,6 +63,7 @@ Function SUB {
             $htmltagparams = @{}
             $tagname = "SUB"
         }
+        
         Process {       
             $CommonParameters = @('tagname') + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
             $CustomParameters = $PSBoundParameters.Keys | ? { $_ -notin $CommonParameters }
@@ -82,10 +83,12 @@ Function SUB {
                 }
             }
         }
+        
         End {
             if ($Attributes) {
                 $htmltagparams += $Attributes
             }
             Set-HtmlTag -TagName $tagname -Attributes $htmltagparams -TagType NonVoid 
+            
         }
     }

--- a/PSHTML/Functions/Public/sub.ps1
+++ b/PSHTML/Functions/Public/sub.ps1
@@ -1,89 +1,81 @@
 Function SUB {
     <#
     .SYNOPSIS
-    Create a SUB title in an HTML document.
-
+        Create a SUB tag in an HTML document.
+    .DESCRIPTION
+        Create a SUB tag in an HTML document. 
     .EXAMPLE
-
-    SUB
-    .EXAMPLE
-    SUB "woop1" -Class "class"
-
-    .EXAMPLE
-    SUB "woop2" -Class "class" -Id "MainTitle"
-
-    .EXAMPLE
-    SUB {"woop3"} -Class "class" -Id "MaintTitle" -Style "color:red;"
-
-    .Notes
-    Author: Chendrayan Venkatesan (Chen V)
-    Version: 1.0.0
-    History:
-        2018.10.17;@ChendrayanV; New Version 1.0.0
+        p -content {
+            "The Chemical Formula for water is H"
+            SUB -Content {
+                2
+            }
+            "O"
+        } 
+    .NOTES
+        Current version 2.0
+        History:
+                2018.10.18;@ChendrayanV;Updated to version 2.0
     .LINK
         https://github.com/Stephanevg/PSHTML
     #>
-    [Cmdletbinding()]
-    Param(
-        [Parameter(Mandatory = $false)]
-        [AllowEmptyString()]
-        [AllowNull()]
-        $Content,
-
-        [AllowEmptyString()]
-        [AllowNull()]
-        [String]$Class,
-
-        [String]$Id,
-
-        [AllowEmptyString()]
-        [AllowNull()]
-        [String]$Style,
-
-        [Hashtable]$Attributes
-    )
-
-    $attr = ""
-    $CommonParameters = ("Attributes", "Content") + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
-    $CustomParameters = $PSBoundParameters.Keys | Where-Object -FilterScript { $_ -notin $CommonParameters }
-
-    if ($CustomParameters) {
-
-        foreach ($entry in $CustomParameters) {
-
-
-            $Attr += "{0}=`"{1}`" " -f $entry, $PSBoundParameters[$entry]
-
+        [Cmdletbinding()]
+        Param(
+    
+            [Parameter(
+                ValueFromPipeline = $true,
+                Mandatory = $false,
+                Position = 0
+            )]
+            [AllowEmptyString()]
+            [AllowNull()]
+            $Content,
+    
+            [string]$cite,
+    
+            [AllowEmptyString()]
+            [AllowNull()]
+            [String]$Class = "",
+    
+            [String]$Id,
+    
+            [AllowEmptyString()]
+            [AllowNull()]
+            [String]$Style,
+    
+            [String]$title,
+    
+            [Hashtable]$Attributes
+        )
+    
+        Begin {
+            
+            $htmltagparams = @{}
+            $tagname = "SUB"
         }
-
-    }
-
-    if ($Attributes) {
-        foreach ($entry in $Attributes.Keys) {
-
-            $attr += "{0}=`"{1}`" " -f $entry, $Attributes[$Entry]
+        Process {       
+            $CommonParameters = @('tagname') + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+            $CustomParameters = $PSBoundParameters.Keys | ? { $_ -notin $CommonParameters }
+            
+            if ($CustomParameters) {
+    
+                Switch ($CustomParameters) {
+                    {($_ -eq 'content') -and ($null -eq $htmltagparams.$_)} {
+                        $htmltagparams.$_ = @($PSBoundParameters[$_])
+                        continue
+                    }
+                    {$_ -eq 'content'} {
+                        $htmltagparams.$_ += $PSBoundParameters[$_]
+                        continue
+                    }
+                    default {$htmltagparams.$_ = "{0}" -f $PSBoundParameters[$_]}
+                }
+            }
+        }
+        End {
+            if ($Attributes) {
+                $htmltagparams += $Attributes
+            }
+            Set-HtmlTag -TagName $tagname -Attributes $htmltagparams -TagType NonVoid 
         }
     }
-
-    if ($attr) {
-        "<SUB {0} >" -f $attr
-    }
-    else {
-        "<SUB>"
-    }
-
-
-    if ($Content) {
-
-        if ($Content -is [System.Management.Automation.ScriptBlock]) {
-            $Content.Invoke()
-        }
-        else {
-            $Content
-        }
-    }
-
-
-    '</SUB>'
-
-}

--- a/PSHTML/Functions/Public/sub.ps1
+++ b/PSHTML/Functions/Public/sub.ps1
@@ -3,7 +3,9 @@ Function SUB {
     .SYNOPSIS
         Create a SUB tag in an HTML document.
     .DESCRIPTION
-        Create a SUB tag in an HTML document. 
+        The <sub> tag defines subscript text. 
+        Subscript text appears half a character below the normal line, and is sometimes rendered in a smaller font. 
+        Subscript text can be used for chemical formulas, like H2O. 
     .EXAMPLE
         p -content {
             "The Chemical Formula for water is H"
@@ -12,6 +14,14 @@ Function SUB {
             }
             "O"
         } 
+        The above example renders the html as illustrated below
+        <p>
+        The Chemical Formula for water is H
+        <SUB>
+            2
+        </SUB>
+        O
+        </p>
     .NOTES
         Current version 2.0
         History:

--- a/PSHTML/Functions/Public/sup.ps1
+++ b/PSHTML/Functions/Public/sup.ps1
@@ -62,6 +62,7 @@ Function SUP {
             $htmltagparams = @{}
             $tagname = "SUP"
         }
+        
         Process {       
             $CommonParameters = @('tagname') + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
             $CustomParameters = $PSBoundParameters.Keys | ? { $_ -notin $CommonParameters }
@@ -81,10 +82,12 @@ Function SUP {
                 }
             }
         }
+        
         End {
             if ($Attributes) {
                 $htmltagparams += $Attributes
             }
             Set-HtmlTag -TagName $tagname -Attributes $htmltagparams -TagType NonVoid 
         }
+        
     }

--- a/PSHTML/Functions/Public/sup.ps1
+++ b/PSHTML/Functions/Public/sup.ps1
@@ -1,87 +1,80 @@
 Function SUP {
     <#
     .SYNOPSIS
-    Create a SUP title in an HTML document.
-
+        Create a SUP tag in an HTML document.
+    .DESCRIPTION
+        Create a SUP tag in an HTML document. 
     .EXAMPLE
-
-    SUP
-    .EXAMPLE
-    SUP "woop1" -Class "class"
-
-    .EXAMPLE
-    SUP "woop2" -Class "class" -Id "MainTitle"
-
-    .EXAMPLE
-    SUP {"woop3"} -Class "class" -Id "MaintTitle" -Style "color:red;"
-
-    .Notes
-    Author: Chendrayan Venkatesan (Chen V)
-    Version: 1.0.0
-    History:
-        2018.10.17;@ChendrayanV; New Version 1.0.0
+        $Power = 3
+        p -content {
+            "The Value of 2"
+            SUP $Power
+            "is {0}" -f ([Math]::Pow(2,$Power))
+        } 
+    .NOTES
+        Current version 2.0
+        History:
+                2018.10.18;@ChendrayanV;Updated to version 2.0
     .LINK
         https://github.com/Stephanevg/PSHTML
     #>
-    [Cmdletbinding()]
-    Param(
-        [Parameter(Mandatory=$false)]
-        [AllowEmptyString()]
-        [AllowNull()]
-        $Content,
-
-        [AllowEmptyString()]
-        [AllowNull()]
-        [String]$Class,
-
-        [String]$Id,
-
-        [AllowEmptyString()]
-        [AllowNull()]
-        [String]$Style,
-
-        [Hashtable]$Attributes
-    )
-
-    $attr = ""
-    $CommonParameters = ("Attributes", "Content") + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
-    $CustomParameters = $PSBoundParameters.Keys | Where-Object -FilterScript { $_ -notin $CommonParameters }
-
-    if($CustomParameters){
-
-        foreach ($entry in $CustomParameters){
-
-
-            $Attr += "{0}=`"{1}`" " -f $entry,$PSBoundParameters[$entry]
-
+        [Cmdletbinding()]
+        Param(
+    
+            [Parameter(
+                ValueFromPipeline = $true,
+                Mandatory = $false,
+                Position = 0
+            )]
+            [AllowEmptyString()]
+            [AllowNull()]
+            $Content,
+    
+            [string]$cite,
+    
+            [AllowEmptyString()]
+            [AllowNull()]
+            [String]$Class = "",
+    
+            [String]$Id,
+    
+            [AllowEmptyString()]
+            [AllowNull()]
+            [String]$Style,
+    
+            [String]$title,
+    
+            [Hashtable]$Attributes
+        )
+    
+        Begin {
+            
+            $htmltagparams = @{}
+            $tagname = "SUP"
         }
-
-    }
-
-    if($Attributes){
-        foreach($entry in $Attributes.Keys){
-
-            $attr += "{0}=`"{1}`" " -f $entry,$Attributes[$Entry]
+        Process {       
+            $CommonParameters = @('tagname') + [System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+            $CustomParameters = $PSBoundParameters.Keys | ? { $_ -notin $CommonParameters }
+            
+            if ($CustomParameters) {
+    
+                Switch ($CustomParameters) {
+                    {($_ -eq 'content') -and ($null -eq $htmltagparams.$_)} {
+                        $htmltagparams.$_ = @($PSBoundParameters[$_])
+                        continue
+                    }
+                    {$_ -eq 'content'} {
+                        $htmltagparams.$_ += $PSBoundParameters[$_]
+                        continue
+                    }
+                    default {$htmltagparams.$_ = "{0}" -f $PSBoundParameters[$_]}
+                }
+            }
+        }
+        End {
+            if ($Attributes) {
+                $htmltagparams += $Attributes
+            }
+            Set-HtmlTag -TagName $tagname -Attributes $htmltagparams -TagType NonVoid 
         }
     }
-
-    if($attr){
-        "<SUP {0} >"  -f $attr
-    }else{
-        "<SUP>"
-    }
-
-
-    if($Content){
-
-        if($Content -is [System.Management.Automation.ScriptBlock]){
-            $Content.Invoke()
-        }else{
-            $Content
-        }
-    }
-
-
-    '</SUP>'
-
-}

--- a/PSHTML/Functions/Public/sup.ps1
+++ b/PSHTML/Functions/Public/sup.ps1
@@ -3,7 +3,9 @@ Function SUP {
     .SYNOPSIS
         Create a SUP tag in an HTML document.
     .DESCRIPTION
-        Create a SUP tag in an HTML document. 
+        The <sup> tag defines superscript text. 
+        Superscript text appears half a character above the normal line, and is sometimes rendered in a smaller font. 
+        Superscript text can be used for footnotes, like WWW[1].
     .EXAMPLE
         $Power = 3
         p -content {
@@ -11,6 +13,14 @@ Function SUP {
             SUP $Power
             "is {0}" -f ([Math]::Pow(2,$Power))
         } 
+        The above example renderes the HTML code as illustrated below
+        <p>
+        The Value of 2
+        <SUP>
+            3
+        </SUP>
+        is 8
+        </p>
     .NOTES
         Current version 2.0
         History:

--- a/Tests/sub.tests.ps1
+++ b/Tests/sub.tests.ps1
@@ -13,22 +13,22 @@ Write-Verbose "Importing module"
 import-module .\PSHTML -Force
 
 Context "Testing PSHTML" {
-    Describe "Testing blockquote" {
+    Describe "Testing SUB" {
 
 
         $Class = "MyClass"
         $Id = "MyID"
         $Style = "Background:green"
         $CustomAtt = @{"MyAttribute1" = 'MyValue1'; "MyAttribute2" = "MyValue2"}
-        $string = blockquote {woop} -Attributes $CustomAtt -Style $Style -Class $class -id $id
+        $string = SUB {woop} -Attributes $CustomAtt -Style $Style -Class $class -id $id
 
         if ($string -is [array]) {
             $string = $String -join ""
         }
 
         it "Should contain opening and closing tags" {
-            $string -match '^<blockquote.*>' | should be $true
-            $string -match '.*</blockquote>$' | should be $true
+            $string -match '^<SUB.*>' | should be $true
+            $string -match '.*</SUB>$' | should be $true
 
         }
 
@@ -37,13 +37,13 @@ Context "Testing PSHTML" {
         }
 
         it "Testing common parameters: Class" {
-            $string -match '^<blockquote.*class="myclass".*>' | should be $true
+            $string -match '^<SUB.*class="myclass".*>' | should be $true
         }
         it "Testing common parameters: ID" {
-            $string -match '^<blockquote.*id="myid".*>' | should be $true
+            $string -match '^<SUB.*id="myid".*>' | should be $true
         }
         it "Testing common parameters: Style" {
-            $string -match '^<blockquote.*style=".+".*>' | should be $true
+            $string -match '^<SUB.*style=".+".*>' | should be $true
         }
 
         it "Testing Attributes parameters" {
@@ -51,31 +51,24 @@ Context "Testing PSHTML" {
             foreach ($at in $CustomAtt.Keys) {
                 $val = $null
                 $val = $CustomAtt[$at]
-                $string -match "^<blockquote.*$at=`"$val`".*>" | should be $true
+                $string -match "^<SUB.*$at=`"$val`".*>" | should be $true
             }
 
 
         }
-
-
     }
-
-    Describe "Testing blockquote with Pipeline" {
-
-
+    Describe "Testing SUB with Pipeline" {
         $Class = "MyClass"
         $Id = "MyID"
         $Style = "Background:green"
         $CustomAtt = @{"MyAttribute1" = 'MyValue1'; "MyAttribute2" = "MyValue2"}
-        $string = p {} | blockquote -Attributes $CustomAtt -Style $Style -Class $class -id $id
-
+        $string = p {} | SUB -Attributes $CustomAtt -Style $Style -Class $class -id $id
         if ($string -is [array]) {
             $string = $String -join ""
         }
-
         it "Should contain opening and closing tags" {
-            $string -match '^<blockquote.*>' | should be $true
-            $string -match '.*</blockquote>$' | should be $true
+            $string -match '^<SUB.*>' | should be $true
+            $string -match '.*</SUB>$' | should be $true
 
         }
 
@@ -84,13 +77,13 @@ Context "Testing PSHTML" {
         }
 
         it "Testing common parameters: Class" {
-            $string -match '^<blockquote.*class="myclass".*>' | should be $true
+            $string -match '^<SUB.*class="myclass".*>' | should be $true
         }
         it "Testing common parameters: ID" {
-            $string -match '^<blockquote.*id="myid".*>' | should be $true
+            $string -match '^<SUB.*id="myid".*>' | should be $true
         }
         it "Testing common parameters: Style" {
-            $string -match '^<blockquote.*style=".+".*>' | should be $true
+            $string -match '^<SUB.*style=".+".*>' | should be $true
         }
 
         it "Testing Attributes parameters" {
@@ -98,13 +91,9 @@ Context "Testing PSHTML" {
             foreach ($at in $CustomAtt.Keys) {
                 $val = $null
                 $val = $CustomAtt[$at]
-                $string -match "^<blockquote.*$at=`"$val`".*>" | should be $true
+                $string -match "^<SUB.*$at=`"$val`".*>" | should be $true
             }
-
-
         }
-
-
     }
 }
 

--- a/Tests/sup.tests.ps1
+++ b/Tests/sup.tests.ps1
@@ -13,22 +13,22 @@ Write-Verbose "Importing module"
 import-module .\PSHTML -Force
 
 Context "Testing PSHTML" {
-    Describe "Testing blockquote" {
+    Describe "Testing SUP" {
 
 
         $Class = "MyClass"
         $Id = "MyID"
         $Style = "Background:green"
         $CustomAtt = @{"MyAttribute1" = 'MyValue1'; "MyAttribute2" = "MyValue2"}
-        $string = blockquote {woop} -Attributes $CustomAtt -Style $Style -Class $class -id $id
+        $string = SUP {woop} -Attributes $CustomAtt -Style $Style -Class $class -id $id
 
         if ($string -is [array]) {
             $string = $String -join ""
         }
 
         it "Should contain opening and closing tags" {
-            $string -match '^<blockquote.*>' | should be $true
-            $string -match '.*</blockquote>$' | should be $true
+            $string -match '^<SUP.*>' | should be $true
+            $string -match '.*</SUP>$' | should be $true
 
         }
 
@@ -37,13 +37,13 @@ Context "Testing PSHTML" {
         }
 
         it "Testing common parameters: Class" {
-            $string -match '^<blockquote.*class="myclass".*>' | should be $true
+            $string -match '^<SUP.*class="myclass".*>' | should be $true
         }
         it "Testing common parameters: ID" {
-            $string -match '^<blockquote.*id="myid".*>' | should be $true
+            $string -match '^<SUP.*id="myid".*>' | should be $true
         }
         it "Testing common parameters: Style" {
-            $string -match '^<blockquote.*style=".+".*>' | should be $true
+            $string -match '^<SUP.*style=".+".*>' | should be $true
         }
 
         it "Testing Attributes parameters" {
@@ -51,31 +51,27 @@ Context "Testing PSHTML" {
             foreach ($at in $CustomAtt.Keys) {
                 $val = $null
                 $val = $CustomAtt[$at]
-                $string -match "^<blockquote.*$at=`"$val`".*>" | should be $true
+                $string -match "^<SUP.*$at=`"$val`".*>" | should be $true
             }
-
-
         }
-
-
     }
 
-    Describe "Testing blockquote with Pipeline" {
+    Describe "Testing SUP with Pipeline" {
 
 
         $Class = "MyClass"
         $Id = "MyID"
         $Style = "Background:green"
         $CustomAtt = @{"MyAttribute1" = 'MyValue1'; "MyAttribute2" = "MyValue2"}
-        $string = p {} | blockquote -Attributes $CustomAtt -Style $Style -Class $class -id $id
+        $string = p {} | SUP -Attributes $CustomAtt -Style $Style -Class $class -id $id
 
         if ($string -is [array]) {
             $string = $String -join ""
         }
 
         it "Should contain opening and closing tags" {
-            $string -match '^<blockquote.*>' | should be $true
-            $string -match '.*</blockquote>$' | should be $true
+            $string -match '^<SUP.*>' | should be $true
+            $string -match '.*</SUP>$' | should be $true
 
         }
 
@@ -84,13 +80,13 @@ Context "Testing PSHTML" {
         }
 
         it "Testing common parameters: Class" {
-            $string -match '^<blockquote.*class="myclass".*>' | should be $true
+            $string -match '^<SUP.*class="myclass".*>' | should be $true
         }
         it "Testing common parameters: ID" {
-            $string -match '^<blockquote.*id="myid".*>' | should be $true
+            $string -match '^<SUP.*id="myid".*>' | should be $true
         }
         it "Testing common parameters: Style" {
-            $string -match '^<blockquote.*style=".+".*>' | should be $true
+            $string -match '^<SUP.*style=".+".*>' | should be $true
         }
 
         it "Testing Attributes parameters" {
@@ -98,7 +94,7 @@ Context "Testing PSHTML" {
             foreach ($at in $CustomAtt.Keys) {
                 $val = $null
                 $val = $CustomAtt[$at]
-                $string -match "^<blockquote.*$at=`"$val`".*>" | should be $true
+                $string -match "^<SUP.*$at=`"$val`".*>" | should be $true
             }
 
 


### PR DESCRIPTION
# New version of SUB and SUP with pester tests
- Added new version for SUP and SUB functions using Set-HTMLTag cmdlet
- Added tests for SUP and SUB functions.
- Code reformat of blockquote.tests.ps1