### PR TITLE
Set html tag

### DIFF
--- a/PSHTML/Functions/Private/Set-HTMLTag.ps1
+++ b/PSHTML/Functions/Private/Set-HTMLTag.ps1
@@ -29,7 +29,7 @@ Function Set-HtmlTag {
 
         $MyCParametersKeys,
 
-        [ValidateSet("void","NonVoid")]
+        [ValidateSet('void','NonVoid')]
         $TagType,
 
         $Content
@@ -45,7 +45,7 @@ Function Set-HtmlTag {
         foreach ($paramkey in $MyCParametersKeys) {
             $paramvalue = Get-Variable $paramkey -ValueOnly -EA SilentlyContinue
             if ($paramvalue -and !$PSBParameters.ContainsKey($paramkey)) {
-                $htmltagparams.$paramkey = $paramvalue
+                $attr += '{0}="{1}" ' -f $paramkey, $paramvalue
             }
         }
         
@@ -63,16 +63,16 @@ Function Set-HtmlTag {
         'Attributes' { 
 
             foreach($entry in $PSBParameters['Attributes'].Keys){
-                if($entry -eq "content" -or $entry -eq "Attributes"){
+                if($entry -eq 'content' -or $entry -eq 'Attributes'){
                     continue
                 }
-                $attr += "{0}=`"{1}`" " -f $entry,$Attributes[$Entry]
+                $attr += '{0}="{1}" ' -f $entry,$Attributes[$Entry]
     }
 
             if($Attributes.Attributes){
                 foreach($at in $Attributes.Attributes.keys){
 
-            $attr += "{0}=`"{1}`" " -f $at,$Attributes.Attributes[$at]
+            $attr += '{0}="{1}" ' -f $at,$Attributes.Attributes[$at]
         }
     }
 
@@ -96,20 +96,20 @@ Function Set-HtmlTag {
 
 
 
-        if($TagType -eq "void"){
-            $Closingtag = "/"
+        if($TagType -eq 'void'){
+            $Closingtag = '/'
             if($attr){
-            $output += "<{0} {1} {2}>"  -f $tagname,$attr,$Closingtag
+            $output += '<{0} {1} {2}>'  -f $tagname,$attr,$Closingtag
             }else{
-            $output += "<{0} {1}>" -f $tagname,$Closingtag
+            $output += '<{0} {1}>' -f $tagname,$Closingtag
             }
             $output
         }else{
             #tag is of type "non-void"
             if($attr){
-                $output += "<{0} {1} >"  -f $tagname,$attr
+                $output += '<{0} {1} >'  -f $tagname,$attr
             }else{
-                $output += "<{0}>" -f $tagname
+                $output += '<{0}>' -f $tagname
             }
 
 
@@ -118,7 +118,7 @@ Function Set-HtmlTag {
             $output += $outcontent
             }
 
-            $output += "</{0}>" -f $tagname
+            $output += '</{0}>' -f $tagname
             $output
         }
     }


### PR DESCRIPTION
<!--
    As a general rule, please be sure you have followed these steps:

    If you are adding a new cmdlet / feature, please validate that:
    1 - You added help
    2 - You added at least 2 examples
    3 - You added a test
-->


# Pull Request 

<!-- 
Write one or two sentences explaining what you have modified.
-->

New version of Set-HTMLTag, It include the tag parameters, no more need to deal with them in the tag function. 
Tags functions are now smallesr, just function params and 1 line of code with Set-HTMLTag

### Please tell us , the type of Change you are submiting:
Select one of the following: 

- [X] Bug
- [X] Feature
- [ ] Minor Change

<!--
    Example:
    [X] Bug
-->

### Does it fix an existing issue? Please tell us which one

<!-- 
    Example
    Resolves #21
    or 
    Fixes #42
--->
Resolves #108 
Resolves #50 
Resolves Part #61

### Description of what's been changed
<!--
    Any details you want to share?
 -->


* Mod : 2 parameters

    * $PSBParameters: $PSBoundParameters from the calling function

    * $MyCParametersKeys: All others Parameters from the calling function

* Add : 2 variables

    * $output : to stock the ouput until the end of the function

    * $outcontent : to stock the ouput content until the $TagType is managed

* Use of a Switch statement for $PSBParameters

### Results of your tests (If applicable)
<!--
    If you add a new test, it would be really great if you can add a screen shot of the results. (not necessary, but, it would be nice)
-->
All your pester tests work with this new function version, only if you modify your tags function with the new format.
I did the tests, and i have all the modified tags, if you want them, i PR...
