### PR TITLE
Added Write-PSHTMLSymbol cmdlet with tests and docs

### DIFF
--- a/PSHTML/Functions/Public/Write-PSHTMLSymbol.ps1
+++ b/PSHTML/Functions/Public/Write-PSHTMLSymbol.ps1
@@ -1,0 +1,126 @@
+function Write-PSHTMLSymbol {
+
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateSet('COPYRIGHT SIGN', 
+            'REGISTERED SIGN', 
+            'EURO SIGN', 
+            'TRADEMARK',
+            'LEFTWARDS ARROW',
+            'UPWARDS ARROW',
+            'RIGHTWARDS ARROW',
+            'DOWNWARDS ARROW',
+            'BLACK SPADE SUIT',
+            'BLACK CLUB SUIT',
+            'BLACK HEART SUIT',
+            'BLACK DIAMOND SUIT',
+            'FOR ALL',
+            'PARTIAL DIFFERENTIAL',
+            'THERE EXISTS',
+            'EMPTY SETS',
+            'NABLA',
+            'ELEMENT OF',
+            'NOT AN ELEMENT OF',
+            'CONTAINS AS MEMBER',
+            'N-ARY PRODUCT',
+            'N-ARY SUMMATION',
+            'GREEK CAPITAL LETTER ALPHA',
+            'GREEK CAPITAL LETTER BETA',
+            'GREEK CAPITAL LETTER GAMMA',
+            'GREEK CAPITAL LETTER DELTA',
+            'GREEK CAPITAL LETTER EPSILON',
+            'GREEK CAPITAL LETTER ZETA'
+        )]
+        [string[]]
+        $Name
+    )
+
+    process {
+        switch ($Name) {
+            "COPYRIGHT SIGN" {
+                "&copy;"
+            }
+            "REGISTERED SIGN" {
+                "&reg;"
+            }
+            "EURO SIGN" {
+                "&euro;"
+            }
+            "TRADEMARK" {
+                "&trade;"
+            }
+            "LEFTWARDS ARROW" {
+                "&larr;"
+            }
+            "UPWARDS ARROW" {
+                "&uarr;"
+            }
+            "RIGHTWARDS ARROW" {
+                "&rarr;"
+            }
+            "DOWNWARDS ARROW" {
+                "&darr;"
+            }
+            "BLACK SPADE SUIT" {
+                "&spades;"
+            }
+            "BLACK CLUB SUIT" {
+                "&clubs;"
+            }
+            "BLACK HEART SUIT" {
+                "&hearts;"
+            }
+            "BLACK DIAMOND SUIT" {
+                "&diams;"
+            }
+            "FOR ALL" {
+                "&forall;"
+            }
+            "PARTIAL DIFFERENTIAL" {
+                "&part;"
+            }
+            "THERE EXISTS" {
+                "&exist;"
+            }
+            "EMPTY SETS" {
+                "&empty;"
+            }
+            "NABLA" {
+                "&nabla;"
+            }
+            "ELEMENT OF" {
+                "&isin;"
+            }
+            "NOT AN ELEMENT OF" {
+                "&notin;"
+            }
+            "CONTAINS AS MEMBER" {
+                "&ni;"
+            }
+            "N-ARY PRODUCT" {
+                "&prod;"
+            }
+            "N-ARY SUMMATION" {
+                "&sum;"
+            }
+            "GREEK CAPITAL LETTER ALPHA" {
+                "&Alpha;"
+            }
+            "GREEK CAPITAL LETTER BETA" {
+                "&Beta;"
+            }
+            "GREEK CAPITAL LETTER GAMMA" {
+                "&Gamma;"
+            }
+            "GREEK CAPITAL LETTER DELTA" {
+                "&Delta;"
+            }
+            "GREEK CAPITAL LETTER EPSILON" {
+                "&Epsilon;"
+            }
+            "GREEK CAPITAL LETTER ZETA" {
+                "&Zeta;"
+            }
+        }
+    }
+}

--- a/Tests/Write-PSHTMLSymbol.Tests.ps1
+++ b/Tests/Write-PSHTMLSymbol.Tests.ps1
@@ -1,0 +1,21 @@
+$TestsPath = Split-Path $MyInvocation.MyCommand.Path
+
+#$FunctionsPath = join-Path -Path (get-item $TestsPath).Parent -ChildPath "Functions"
+
+$RootFolder = (get-item $TestsPath).Parent
+
+Push-Location -Path $RootFolder.FullName
+
+set-location -Path $RootFolder.FullName
+
+Write-Verbose "Importing module"
+
+import-module .\PSHTML -Force
+
+Describe 'Write-PSHTMLSymbol' {
+    $Value = "GREEK CAPITAL LETTER ZETA"
+    $Result = Write-PSHTMLSymbol -Name 'GREEK CAPITAL LETTER ZETA'
+    it 'should return &Zeta;' {
+        $Result | should be '&Zeta;'
+    }
+}

--- a/docs/Write-PSHTMLSymbol.md
+++ b/docs/Write-PSHTMLSymbol.md
@@ -1,0 +1,98 @@
+---
+external help file: pshtml-help.xml
+Module Name: PSHTML
+online version:
+schema: 2.0.0
+---
+
+# Write-PSHTMLSymbol
+
+## SYNOPSIS
+A PowerShell cmdlet to add a HTML symbol
+
+## SYNTAX
+
+``` powershell
+Write-PSHTMLSymbol [-Name] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+A PowerShell cmdlet to add a HTML symbol. Refer https://www.w3schools.com/html/html_symbols.asp for more information about supported symbols
+
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+``` powershell
+html -Content {
+    head -Content {
+        Title -Content "Symbol Test"
+    }
+
+    body -Content {
+        Write-PSHTMLSymbol -Name 'EURO SIGN'
+    }
+} 
+```
+
+
+### EXAMPLE 2
+
+``` powershell
+html -Content {
+    head -Content {
+        Title -Content "Symbol Test"
+    }
+
+    body -Content {
+        Write-PSHTMLSymbol -Name 'EURO SIGN' , 'BLACK CLUB SUIT'
+    }
+} 
+```
+
+### EXAMPLE 3
+
+```powershell
+html -Content {
+    head -Content {
+        Title -Content "Symbol Test"
+    }
+
+    body -Content {
+        'EURO SIGN' , 'BLACK CLUB SUIT' | Write-PSHTMLSymbol
+    }
+} 
+```
+
+## PARAMETERS
+
+### -Name
+{{Fill Object Description}}
+
+```yaml
+Type: Name
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Current version 0.6
+History:
+   2018.05.09;stephanevg;Creation.
+
+## RELATED LINKS


### PR DESCRIPTION
For the design discussion #97 I have added the Write-PSHTMLSymbol cmdlet 

```PowerShell
html -Content {
    head -Content {
        Title -Content "Symbol Test"
    }

    body -Content {
        'EURO SIGN' , 'BLACK CLUB SUIT' | Write-PSHTMLSymbol
    }
} 
```

Output

```HTML
<html ><head ><title >Symbol Test</title></head><Body >&euro;&clubs;</Body></html>
```