### PR TITLE
fix link to png in help doc

### DIFF
--- a/docs/_HowToUsePSHTML.md
+++ b/docs/_HowToUsePSHTML.md
@@ -108,7 +108,7 @@ html {
 ```
 Which generate the following HTML page :
 
-![screen shot of PSHTML ConvertTo-HTMLtable results](/Examples/Example-ConvertTo-HTMLtable.png)
+![screen shot of PSHTML ConvertTo-HTMLtable results](/PSHTML/Examples/Example-ConvertTo-HTMLtable.png)
 
 # Dynamic pages:
 


### PR DESCRIPTION
Please fill in all placeholders --> [Placeholder]

<!--
    As a general rule, please be sure you have followed these steps:

    If you are adding a new cmdlet / feature, please validate that:
    1 - You added help
    2 - You added at least 2 examples
    3 - You added a test
-->


# Pull Request [Topic]
Modified URL that was pointing to the PNG. Added the PSHTML directory



### Please tell us , the type of Change you are submiting:
Select one of the following: 

- [X] Bug
- [ ] Feature
- [ ] Minor Change

### Does it fix an existing issue? Please tell us which one
Fixes issue 166 
https://github.com/Stephanevg/PSHTML/issues/166


### Description of what's been changed
<!--
    Any details you want to share?
 -->

### Results of your tests (If applicable)
<!--
    If you add a new test, it would be really great if you can add a screen shot of the results. (not necessary, but, it would be nice)
-->
